### PR TITLE
Fix for chain coefficients with diverging SDs

### DIFF
--- a/ChainOhmT/mcdis2.jl
+++ b/ChainOhmT/mcdis2.jl
@@ -69,8 +69,7 @@ MCDIS Multiple-component discretization procedure.
     in multi-component form.
 """
 
-function mcdis(N,eps0,quad::Function,Nmax,idelta,mc,AB,wf,mp,irout)
-
+function mcdis(N,eps0,quad::Function,Nmax,idelta,mc,AB,wf,mp,irout,jacobi=zeros(mc, 2))
     suc = true
     f = "Ncap exceeds Nmax in mcdis with irout = "
     if N<1
@@ -97,14 +96,13 @@ function mcdis(N,eps0,quad::Function,Nmax,idelta,mc,AB,wf,mp,irout)
         return [ab,Ncap,kount,suc,uv]
       end
       mtNcap = mc*Ncap
-
-      jacs = r_jacobi(Ncap,0,0.0)
-      uv = gauss(Ncap,jacs)
+      jacs = [r_jacobi(Ncap,jacobi[i,2],jacobi[i,1]) for i in 1:mc]
+      uv = [gauss(Ncap,j) for j in jacs]
 
       xwm = Array{Float64}(undef, mc*Ncap, 2)
       for i=1:mc
         im1tn = (i-1)*Ncap
-        xw = quad(Ncap,i,uv,mc,AB,wf)
+        xw = quad(Ncap,i,uv[i],mc,AB,wf)
         xwm[im1tn+1:im1tn+Ncap,:] = xw
       end
 

--- a/ChainOhmT/quadohmT.jl
+++ b/ChainOhmT/quadohmT.jl
@@ -69,7 +69,8 @@ end
     decreasing exponential instead of a Heaviside function.
 
 """
-function ohmicspectraldensity_finiteT(x,i,α,s,ωc,β; smooth=false)
+function ohmicspectraldensity_finiteT(x,i,α,s,ωc,β; smooth=false, jacobi=true)
+    jweight = @. (abs(x)*2/ωc)^(s-1)
     if i==1
         y = 0
     elseif i==2
@@ -87,7 +88,7 @@ function ohmicspectraldensity_finiteT(x,i,α,s,ωc,β; smooth=false)
     elseif i==4
         y = 0
     end
-    return y
+    return jacobi ? y ./ jweight : y
 end
 
 """
@@ -110,4 +111,9 @@ function fermionicspectraldensity_finiteT(x, i, β, chain, ϵ, J)
         y = 0
     end
     return y
+end
+
+
+function jacweight(x, i, AB, jacobi)
+    return @. ((AB[i, 2]-x)*2/(AB[i, 2]-AB[i, 1]))^jacobi[i, 2]*((x-AB[i, 1])*2/(AB[i, 2]-AB[i, 1]))^jacobi[i, 1]
 end

--- a/docs/src/examples/tailored_sd.md
+++ b/docs/src/examples/tailored_sd.md
@@ -140,3 +140,24 @@ end
 ```
 
 Next, similarly to the spin-boson example, the simulation parameters are set with the initial MPO and MPS in order to carry out the dynamics propagation. Therefore, this modified example shows an easy way to tailor the spectral density for any system and Hamiltonian.
+
+## Dealing with diverging spectral densities
+
+Here, we explain how the `jacobi` parameter of [`MPSDynamics.chaincoeffs_finiteT`](@ref) can help in the case of diverging (but integrable) spectral densities. The most commonly encountered case is for sub-Ohmic (``s<1``) spectral densities at finite temperature, where due to the ``\coth(\beta\omega/2)`` term, the temperature-dependent spectral density scales a ``J_\beta(\omega) \sim |\omega|^{s-1}`` near ``\omega=0``. The `jacobi` parameter allows you to use a specific integrator that performs better for these types of divergences.
+
+The `jacobi` parameter takes in a matrix with the same shape as `AB`. Each row of `jacobi` corresponds to an interval of `AB`, and the first and second column correspond to the scaling exponent of the spectral density near the left and right interval boundary respectively (should be 0 otherwise). This is only available for finite intervals, so it might be necessary to further split the spectral density support in more `AB` intervals.
+
+Taking the same spectral density as the continuous case of [The code to define a specific spectral density](@ref), it scales as ``\sim \omega^{s-1}`` both near the right boundary of the interval `AB[2]=[-ωc 0]` and near the left boundary of interval `AB[3]=[0 ωc]`. Thus the code to generate the chain coefficients is slightly modified as such.
+
+```julia
+#-----------------------
+# Calculation of chain parameters
+#-----------------------
+
+@assert Jω_type==:Continuous "use the continuous spectral density"
+@assert !isinf(β) "should be the finite-temperature case (use a finite β)"
+
+jacobi = [[0 0];[0 s-1];[s-1 0];[0 0]]
+
+cpars = chaincoeffs_finiteT(N, β, false; α=α, s=s, J=Jω_fct, ωc=ωc, mc=size(AB)[1], mp=0, AB=AB, iq=1, idelta=2, procedure=:Lanczos, Mmax=5000, save=false, jacobi=jacobi)  # chain parameters, i.e. on-site energies ϵ_i, hopping energies t_i, and system-chain coupling c_0
+```

--- a/src/finitetemperature.jl
+++ b/src/finitetemperature.jl
@@ -28,8 +28,9 @@ Users can provide their own spectral density.
 * Mmax: maximum number of integration points
 * save: if true the coefficients are saved
 * smooth: if true the spectral density is multiplied by a decreasing exponential instead of a Heaviside function.
+* jacobi: Jacobi weight function parameters for each interval of AB. Can help with integration of diverging SDs. If the (thermalized) SD behaves as ``\\sim ω^s`` at the left and as ``\\sim ω^q`` to the right of an interval i, the mc-by-2 matrix `jacobi` should have `jacobi[i,:] = [s, q]` (all other entries should be 0). 
 """
-function chaincoeffs_finiteT(nummodes, β, ohmic=true; α=1, s=1, J=nothing, ωc=1, mc=4, mp=0, AB=nothing, iq=1, idelta=2, procedure=:Lanczos, Mmax=5000, save=true, smooth=false)
+function chaincoeffs_finiteT(nummodes, β, ohmic=true; α=1, s=1, J=nothing, ωc=1, mc=4, mp=0, AB=nothing, iq=1, idelta=2, procedure=:Lanczos, Mmax=5000, save=true, smooth=false, jacobi=nothing)
 
     N = nummodes #Number of bath modes
 
@@ -37,20 +38,26 @@ function chaincoeffs_finiteT(nummodes, β, ohmic=true; α=1, s=1, J=nothing, ωc
     if AB==nothing 
         if mc==4
             AB = [[-Inf -ωc];[-ωc 0];[0 ωc];[ωc Inf]]
+            smooth && @warn "It is advised to specify the AB intervals with smooth=true, current segments imply a hard cutoff at ωc=$ωc. \
+            Example use: AB=[[-Inf -5*ωc];[-5*ωc 0];[0 5*ωc];[5*ωc Inf]]"
         else
             throw(ArgumentError("An interval AB with mc = $mc components should have been provided."))
         end
     elseif size(AB)[1] != mc
         throw(ArgumentError("AB has a different number of intervals than mc = $mc."))             
     end
-    
+ 
     # Express the spectral density according to the intervals
     if ohmic==true
-        wf(x,i) = ohmicspectraldensity_finiteT(x,i,α,s,ωc,β; smooth=smooth)
-    elseif J==nothing
+        jacobi = [[0 0];[0 s-1];[s-1 0];[0 0]]
+        wf = (x,i) -> ohmicspectraldensity_finiteT(x,i,α,s,ωc,β; smooth=smooth, jacobi=true) 
+    elseif isnothing(J)
         throw(ArgumentError("A spectral density should have been provided."))
     else
-        wf = J
+        jacobi = isnothing(jacobi) ? zeros(mc, 2) : jacobi
+        @assert size(jacobi) == (mc, 2) "jacobi should be a mc=$mc by 2 matrix with the 2 Jacobi weight parameters for each interval of AB"
+        @assert !any(any(jacobi .!= 0, dims=2) .&& any(isinf, AB, dims=2)) "non-zero jacobi can only be used on finite intervals"
+        wf = (x,i) -> J(x,i)./jacweight(x,i,AB,jacobi) 
     end
     
     # Choose the procedure to calculate the chain coefficients
@@ -67,7 +74,7 @@ function chaincoeffs_finiteT(nummodes, β, ohmic=true; α=1, s=1, J=nothing, ωc
     jacerg = zeros(N,2)
 
     ab = 0.
-    ab, Mcap, kount, suc, uv = mcdis(N,eps0,quadfinT,Mmax,idelta,mc,AB,wf,mp,irout) # Calculate the chain coefficients
+    ab, Mcap, kount, suc, uv = mcdis(N,eps0,quadfinT,Mmax,idelta,mc,AB,wf,mp,irout,jacobi) # Calculate the chain coefficients
     for m = 1:N-1
         jacerg[m,1] = ab[m,1] #site energy e
         jacerg[m,2] = sqrt(ab[m+1,2]) #hopping parameter t
@@ -77,7 +84,7 @@ function chaincoeffs_finiteT(nummodes, β, ohmic=true; α=1, s=1, J=nothing, ωc
     # Calculate the integral of the spectral density to get system-chain coupling c
     eta = 0.
     for i = 1:mc
-        xw = quadfinT(Mcap,i,uv,mc,AB,wf)
+        xw = quadfinT(Mcap,i,uv[i],mc,AB,wf)
         eta += sum(xw[:,2])
     end
     jacerg[N,2] = sqrt(eta) # system-chain coupling c


### PR DESCRIPTION
This adds a fix for chain coefficients generation with diverging SDs (actually any SD that has a power-law behavior near a finite point). Adds a `jacobi` kwarg to `chaincoeffs_finiteT` specifying the power-law exponent followed by the SD near each interval endpoint (keep at 0 where it isn't needed).

It works by using the nodes and weights of `r_jacobi` with non-zero Jacobi parameters `a` and `b` in `mcdis`, which are better suited for SDs that can be expressed as $J(x)=\phi(x)*(1-x)^a(1+x)^b$ where $\phi(x)$ is a smooth function (once re-scaled from their original interval to $[-1, 1]$). There is additional code to multiply the user-inputted spectral density by the correct re-scaled weight so that they don't have to compute $\phi(x)$ themselves. The default finite-temperature Ohmic case now uses the fixed version. A small guide on how to use it is added in a new section of the "Tailoring the spectral density" guide of Examples.

I'm currently adding a few tests to check that everything works as expected, but feel free to change anything or make any comment.